### PR TITLE
Header BG IMage fix

### DIFF
--- a/layout.tpl
+++ b/layout.tpl
@@ -85,8 +85,7 @@
 				</div>
 			</nav>
 
-			<header class="header"{if $core.config.website_bg} style="background-image: url('{$smarty.const.IA_CLEAR_URL}uploads/{$core.config.website_bg}');"{/if}>
-
+			<header class="header"{if $core.config.website_bg} style="background-image: url('{$core.page.nonProtocolUrl}uploads/{$core.config.website_bg}');"{/if}>
 				{ia_blocks block='teaser'}
 			</header>
 


### PR DESCRIPTION
When multi language switch turned on, header bg image was not working
because folder path was added with language code.